### PR TITLE
add cover to PDF

### DIFF
--- a/.github/workflows/pandoc.yaml
+++ b/.github/workflows/pandoc.yaml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: list-files
-        run: echo "chapter=$(ls -1 Chapter*.md | grep -v 'Chapter00.md' | sort -V | tr '\n' ' ' | sed 's/ $//')" >> "$GITHUB_OUTPUT"
+        run: tlmgr install wallpaper && tlmgr install eso-pic
+      - run: echo "chapter=$(ls -1 Chapter*.md | grep -v 'Chapter00.md' | sort -V | tr '\n' ' ' | sed 's/ $//')" >> "$GITHUB_OUTPUT"
       - run: pandoc Chapter00.md -o preface.tex
       - run: pandoc -d config.yaml --template template.tex -B preface.tex ${{ steps.list-files.outputs.chapter }} -o guide.pdf
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/pandoc.yaml
+++ b/.github/workflows/pandoc.yaml
@@ -19,12 +19,12 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
       - uses: actions/checkout@v4
-      - id: list-files
-        run: tlmgr update --self
-      - run: tlmgr install wallpaper && tlmgr install eso-pic
-      - run: echo "chapter=$(ls -1 Chapter*.md | grep -v 'Chapter00.md' | sort -V | tr '\n' ' ' | sed 's/ $//')" >> "$GITHUB_OUTPUT"
-      - run: pandoc Chapter00.md -o preface.tex
-      - run: pandoc -d config.yaml --template template.tex -B preface.tex ${{ steps.list-files.outputs.chapter }} -o guide.pdf
+      - run: |
+          tlmgr update --self
+          tlmgr install wallpaper && tlmgr install eso-pic
+          chapter=$(ls -1 Chapter*.md | grep -v 'Chapter00.md' | sort -V | tr '\n' ' ' | sed 's/ $//')
+          pandoc Chapter00.md -o preface.tex
+          pandoc -d config.yaml --template template.tex -B preface.tex $chapter -o guide.pdf
       - uses: actions/upload-artifact@v4
         with:
           name: guide.pdf

--- a/.github/workflows/pandoc.yaml
+++ b/.github/workflows/pandoc.yaml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: list-files
-        run: tlmgr install wallpaper && tlmgr install eso-pic
+        run: tlmgr update --self
+      - run: tlmgr install wallpaper && tlmgr install eso-pic
       - run: echo "chapter=$(ls -1 Chapter*.md | grep -v 'Chapter00.md' | sort -V | tr '\n' ' ' | sed 's/ $//')" >> "$GITHUB_OUTPUT"
       - run: pandoc Chapter00.md -o preface.tex
       - run: pandoc -d config.yaml --template template.tex -B preface.tex ${{ steps.list-files.outputs.chapter }} -o guide.pdf

--- a/.github/workflows/root.yaml
+++ b/.github/workflows/root.yaml
@@ -9,6 +9,7 @@ on:
       - Chapter*.md
       - image/**
       - listing.tex
+      - template.tex
       - .github/workflows/pandoc.yaml
       - .github/workflows/root.yaml
 

--- a/template.tex
+++ b/template.tex
@@ -669,7 +669,6 @@ $endfor$
 \thispagestyle{empty}
 \vspace*{\fill}
   \textbf{\LARGE Linux標準教科書}
-
   \vspace{1cm}
   \rule{\textwidth}{0.5pt}
 

--- a/template.tex
+++ b/template.tex
@@ -540,8 +540,27 @@ $if(logo)$
 \logo{\includegraphics{$logo$}}
 $endif$
 $endif$
-
+\usepackage{wallpaper}
 \begin{document}
+
+\thispagestyle{empty}
+\ThisCenterWallPaper{1}{image/Cover/cover.png}
+\null
+\cleardoublepage
+
+\thispagestyle{empty}
+\begin{center}
+  \vspace*{2cm}
+  {\Huge Linux標準教科書}
+
+  \vspace{1cm}
+  {\Large 2024年12月16日 v4.0.0版発行}
+
+  \vspace{0.5cm}
+  {\Large 発行元: LPI-Japan}
+\end{center}
+\newpage
+
 $if(has-frontmatter)$
 \frontmatter
 $endif$
@@ -646,4 +665,16 @@ $include-after$
 
 $endfor$
 %% \includepdf[pages=-, noautoscale=true, scale=1.0]{中表紙後.pdf}
+\newpage
+\thispagestyle{empty}
+\vspace*{\fill}
+  \textbf{\LARGE Linuxサーバー構築標準教科書}
+
+  \rule{\textwidth}{0.5pt}
+
+  2024年2月1日 v4.0版発行\\
+  発行元 LPI-Japan\\
+  \rule{\textwidth}{0.5pt}
+
+  \copyright{} 2024 LPI-Japan. All Rights Reserved.
 \end{document}

--- a/template.tex
+++ b/template.tex
@@ -669,9 +669,9 @@ $endfor$
 \thispagestyle{empty}
 \vspace*{\fill}
   \textbf{\LARGE Linux標準教科書}
-  \vspace{1cm}
-  \rule{\textwidth}{0.5pt}
 
+  \rule{\textwidth}{0.5pt}
+  
   2024年12月16日 v4.0.0版発行\\
   発行元 LPI-Japan\\
   \rule{\textwidth}{0.5pt}

--- a/template.tex
+++ b/template.tex
@@ -668,11 +668,12 @@ $endfor$
 \newpage
 \thispagestyle{empty}
 \vspace*{\fill}
-  \textbf{\LARGE Linuxサーバー構築標準教科書}
+  \textbf{\LARGE Linux標準教科書}
 
+  \vspace{1cm}
   \rule{\textwidth}{0.5pt}
 
-  2024年2月1日 v4.0版発行\\
+  2024年12月16日 v4.0.0版発行\\
   発行元 LPI-Japan\\
   \rule{\textwidth}{0.5pt}
 


### PR DESCRIPTION
pandocをアップデートしてしまうと\pandocboundedが存在しないというエラーを吐かれてしまう+表紙を作るのにパッケージを追加するために以下のコマンドを走らせる必要があるため、暫定対応としてpandoc.yaml内で行っています
```
          tlmgr update --self
          tlmgr install wallpaper && tlmgr install eso-pic
```